### PR TITLE
Feat/#18 마이페이지 예매 정보 보여주는 로직 추가

### DIFF
--- a/src/main/java/com/miml/c2k/domain/member/Member.java
+++ b/src/main/java/com/miml/c2k/domain/member/Member.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "members")
+@Table(name = "member")
 @NoArgsConstructor
 public class Member {
 

--- a/src/main/java/com/miml/c2k/domain/member/controller/MemberController.java
+++ b/src/main/java/com/miml/c2k/domain/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package com.miml.c2k.domain.member.controller;
 import com.miml.c2k.domain.member.dto.MemberResponseDto;
 import com.miml.c2k.domain.member.dto.MemberUpdateDto;
 import com.miml.c2k.domain.member.service.MemberService;
+import com.miml.c2k.domain.ticket.dto.TicketInfoResponseDto;
+import com.miml.c2k.domain.ticket.service.TicketService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public class MemberController {
 
     private final MemberService memberService;
+    private final TicketService ticketService;
 
     @GetMapping("/api/v1/members")
     public ResponseEntity<List<MemberResponseDto>> findAllMembers() {
@@ -25,17 +28,24 @@ public class MemberController {
     }
 
     @GetMapping("/myPage")
-    public String myPage(@RequestHeader(name = "accessToken") String accessToken, Model model) {
+    public String showMyPage(@RequestHeader(name = "accessToken") String accessToken, Model model) {
         MemberResponseDto memberResponseDto = memberService.findMemberByAccessToken(accessToken);
 
+        List<TicketInfoResponseDto> ticketInfoResponseDtos = ticketService.getAllTicketsInfoByMemberId(
+            memberResponseDto.getId());
+
         model.addAttribute("memberResponseDto", memberResponseDto);
+        model.addAttribute("ticketInfoResponseDtos", ticketInfoResponseDtos);
 
         return "/myPage/myPage";
     }
 
     @PutMapping("/api/v1/myPage") //To Do: 추후에 프론트 뷰 수정해서 리다이렉트 하는 api로 수정
-    public ResponseEntity<MemberResponseDto> update(@RequestHeader(name = "accessToken") String accessToken, @RequestBody MemberUpdateDto updateMemberDto) {
-        MemberResponseDto memberResponseDto = memberService.updateMember(accessToken, updateMemberDto);
+    public ResponseEntity<MemberResponseDto> update(
+        @RequestHeader(name = "accessToken") String accessToken,
+        @RequestBody MemberUpdateDto updateMemberDto) {
+        MemberResponseDto memberResponseDto = memberService.updateMember(accessToken,
+            updateMemberDto);
 
         return ResponseEntity.ok(memberResponseDto);
     }

--- a/src/main/java/com/miml/c2k/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/miml/c2k/domain/member/dto/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.miml.c2k.domain.member.dto;
 
+import com.miml.c2k.domain.member.Member;
 import com.miml.c2k.domain.member.OAuthProvider;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -8,17 +9,27 @@ import lombok.Getter;
 @Getter
 public class MemberResponseDto {
 
+    private final Long id;
     private final String nickname;
     private final String email;
     private final OAuthProvider oAuthProvider;
     private final LocalDateTime createdAt;
 
     @Builder
-    public MemberResponseDto(String nickname, String email, OAuthProvider oAuthProvider, LocalDateTime createdAt) {
+    private MemberResponseDto(Long id, String nickname, String email, OAuthProvider oAuthProvider, LocalDateTime createdAt) {
+        this.id = id;
         this.nickname = nickname;
         this.email = email;
         this.oAuthProvider = oAuthProvider;
         this.createdAt = createdAt;
     }
 
+    public static MemberResponseDto create(Member member) {
+        return MemberResponseDto.builder()
+            .nickname(member.getNickname())
+            .email(member.getEmail())
+            .oAuthProvider(member.getOAuthProvider())
+            .createdAt(member.getCreatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/miml/c2k/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/miml/c2k/domain/member/dto/MemberResponseDto.java
@@ -26,6 +26,7 @@ public class MemberResponseDto {
 
     public static MemberResponseDto create(Member member) {
         return MemberResponseDto.builder()
+            .id(member.getId())
             .nickname(member.getNickname())
             .email(member.getEmail())
             .oAuthProvider(member.getOAuthProvider())

--- a/src/main/java/com/miml/c2k/domain/member/service/MemberService.java
+++ b/src/main/java/com/miml/c2k/domain/member/service/MemberService.java
@@ -33,12 +33,7 @@ public class MemberService {
     public MemberResponseDto findMemberByAccessToken(String accessToken) {
         Member member = findMember(accessToken);
 
-        return MemberResponseDto.builder()
-                .nickname(member.getNickname())
-                .email(member.getEmail())
-                .oAuthProvider(member.getOAuthProvider())
-                .createdAt(member.getCreatedAt())
-                .build();
+        return MemberResponseDto.create(member);
     }
 
     @Transactional
@@ -47,12 +42,7 @@ public class MemberService {
 
         member.update(memberUpdateDto.nickname());
 
-        return MemberResponseDto.builder()
-                .nickname(member.getNickname())
-                .email(member.getEmail())
-                .oAuthProvider(member.getOAuthProvider())
-                .createdAt(member.getCreatedAt())
-                .build();
+        return MemberResponseDto.create(member);
     }
 
     private Member findMember(String accessToken) {

--- a/src/main/java/com/miml/c2k/domain/payment/Payment.java
+++ b/src/main/java/com/miml/c2k/domain/payment/Payment.java
@@ -5,8 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Payment {
 
     @Id
@@ -14,5 +16,5 @@ public class Payment {
     private Long id;
 
     @Column(name = "amount", nullable = false)
-    private Long amount;
+    private long amount;
 }

--- a/src/main/java/com/miml/c2k/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/repository/ScheduleRepository.java
@@ -2,6 +2,7 @@ package com.miml.c2k.domain.schedule.repository;
 
 import com.miml.c2k.domain.movie.Movie;
 import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.screen.Screen;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,4 +28,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query(value = "SELECT m FROM Movie m JOIN Schedule s ON m.id = s.movie.id WHERE s.id = :scheduleId")
     Optional<Movie> findMovieByScheduleId(Long scheduleId);
+
+    @Query(value = "SELECT sc FROM Screen sc JOIN Schedule s ON sc.id = s.screen.id")
+    Optional<Screen> findScreenByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/miml/c2k/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/repository/ScheduleRepository.java
@@ -5,6 +5,7 @@ import com.miml.c2k.domain.schedule.Schedule;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -23,4 +24,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         + "JOIN FETCH Screen sc ON sc.id = sche.screen.id "
         + "WHERE sc.theater.id = :theaterId AND Date(sche.startTime) = :date AND sche.movie.id = :movieId")
     List<Schedule> findAllByMovieIdAndTheaterIdAndDate(Long movieId, Long theaterId, LocalDate date);
+
+    @Query(value = "SELECT m FROM Movie m JOIN Schedule s ON m.id = s.movie.id WHERE s.id = :scheduleId")
+    Optional<Movie> findMovieByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/miml/c2k/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/repository/ScheduleRepository.java
@@ -14,21 +14,21 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
-    @Query("SELECT distinct s.movie FROM Schedule s WHERE s.startTime > :currentTime")
+    @Query("SELECT distinct sch.movie FROM Schedule sch WHERE sch.startTime > :currentTime")
     List<Movie> findMoviesStartingAfterCurrentTime(LocalDateTime currentTime);
 
-    @Query("SELECT count(s) FROM Schedule s WHERE (s.screen.id = :screenId) AND ((s.startTime BETWEEN :startTime AND :endTime) OR (s.endTime BETWEEN :startTime AND :endTime))")
+    @Query("SELECT count(sch) FROM Schedule sch WHERE (sch.screen.id = :screenId) AND ((sch.startTime BETWEEN :startTime AND :endTime) OR (sch.endTime BETWEEN :startTime AND :endTime))")
     int countAllByScreenIdBetweenTimeline(Long screenId, LocalDateTime startTime,
             LocalDateTime endTime);
 
-    @Query(value = "SELECT sche FROM Schedule sche "
-        + "JOIN FETCH Screen sc ON sc.id = sche.screen.id "
-        + "WHERE sc.theater.id = :theaterId AND Date(sche.startTime) = :date AND sche.movie.id = :movieId")
+    @Query(value = "SELECT sch FROM Schedule sch "
+        + "JOIN FETCH Screen scr ON scr.id = sch.screen.id "
+        + "WHERE scr.theater.id = :theaterId AND Date(sch.startTime) = :date AND sch.movie.id = :movieId")
     List<Schedule> findAllByMovieIdAndTheaterIdAndDate(Long movieId, Long theaterId, LocalDate date);
 
-    @Query(value = "SELECT m FROM Movie m JOIN Schedule s ON m.id = s.movie.id WHERE s.id = :scheduleId")
+    @Query(value = "SELECT m FROM Movie m JOIN Schedule sch ON m.id = sch.movie.id WHERE sch.id = :scheduleId")
     Optional<Movie> findMovieByScheduleId(Long scheduleId);
 
-    @Query(value = "SELECT sc FROM Screen sc JOIN Schedule s ON sc.id = s.screen.id")
+    @Query(value = "SELECT scr FROM Screen scr JOIN Schedule sch ON scr.id = sch.screen.id")
     Optional<Screen> findScreenByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/miml/c2k/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/miml/c2k/domain/seat/repository/SeatRepository.java
@@ -12,4 +12,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 
     @Query("SELECT s FROM Seat s JOIN Ticket t ON s.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
     List<Seat> findAllReservedSeatsByScheduleId(Long scheduleId);
+
+    @Query(value = "SELECT s FROM Seat s WHERE s.ticket.id = :ticketId")
+    List<Seat> findAllByTicketId(Long ticketId);
 }

--- a/src/main/java/com/miml/c2k/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/miml/c2k/domain/seat/repository/SeatRepository.java
@@ -7,12 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    @Query(value = "SELECT count(s) FROM Seat s JOIN Ticket t ON s.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
+    @Query(value = "SELECT count(se) FROM Seat se JOIN Ticket t ON se.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
     int countReservedSeatsByScheduleId(Long scheduleId);
 
-    @Query("SELECT s FROM Seat s JOIN Ticket t ON s.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
+    @Query("SELECT se FROM Seat se JOIN Ticket t ON se.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
     List<Seat> findAllReservedSeatsByScheduleId(Long scheduleId);
 
-    @Query(value = "SELECT s FROM Seat s WHERE s.ticket.id = :ticketId")
+    @Query(value = "SELECT se FROM Seat se WHERE se.ticket.id = :ticketId")
     List<Seat> findAllByTicketId(Long ticketId);
 }

--- a/src/main/java/com/miml/c2k/domain/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/miml/c2k/domain/theater/repository/TheaterRepository.java
@@ -1,8 +1,12 @@
 package com.miml.c2k.domain.theater.repository;
 
 import com.miml.c2k.domain.theater.Theater;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TheaterRepository extends JpaRepository<Theater, Long> {
 
+    @Query(value = "SELECT t FROM Theater t JOIN Screen s ON t.id = s.theater.id WHERE s.id = :screenId")
+    Optional<Theater> findByScreenId(Long screenId);
 }

--- a/src/main/java/com/miml/c2k/domain/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/miml/c2k/domain/theater/repository/TheaterRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface TheaterRepository extends JpaRepository<Theater, Long> {
 
-    @Query(value = "SELECT t FROM Theater t JOIN Screen s ON t.id = s.theater.id WHERE s.id = :screenId")
+    @Query(value = "SELECT t FROM Theater t JOIN Screen scr ON t.id = scr.theater.id WHERE scr.id = :screenId")
     Optional<Theater> findByScreenId(Long screenId);
 }

--- a/src/main/java/com/miml/c2k/domain/ticket/dto/TicketInfoResponseDto.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/dto/TicketInfoResponseDto.java
@@ -14,7 +14,7 @@ public record TicketInfoResponseDto(String movieTitle,
                                     int screenNum,
                                     long paymentFee) {
 
-    public TicketInfoResponseDto create(Movie movie, Theater theater, Schedule schedule, Screen screen, Payment payment) {
+    public static TicketInfoResponseDto create(Movie movie, Theater theater, Schedule schedule, Screen screen, Payment payment) {
         return new TicketInfoResponseDto(movie.getTitle(),
             movie.getPoster(),
             theater.getName(),

--- a/src/main/java/com/miml/c2k/domain/ticket/dto/TicketInfoResponseDto.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/dto/TicketInfoResponseDto.java
@@ -4,22 +4,26 @@ import com.miml.c2k.domain.movie.Movie;
 import com.miml.c2k.domain.payment.Payment;
 import com.miml.c2k.domain.schedule.Schedule;
 import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.seat.Seat;
 import com.miml.c2k.domain.theater.Theater;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record TicketInfoResponseDto(String movieTitle,
                                     String poster,
                                     String theaterName,
                                     LocalDateTime startTime,
                                     int screenNum,
+                                    List<String> seats,
                                     long paymentFee) {
 
-    public static TicketInfoResponseDto create(Movie movie, Theater theater, Schedule schedule, Screen screen, Payment payment) {
+    public static TicketInfoResponseDto create(Movie movie, Theater theater, Schedule schedule, Screen screen, Payment payment, List<Seat> seats) {
         return new TicketInfoResponseDto(movie.getTitle(),
             movie.getPoster(),
             theater.getName(),
             schedule.getStartTime(),
             screen.getNum(),
+            seats.stream().map(seat -> seat.getName().name()).toList(),
             payment.getAmount());
     }
 }

--- a/src/main/java/com/miml/c2k/domain/ticket/dto/TicketInfoResponseDto.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/dto/TicketInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.miml.c2k.domain.ticket.dto;
+
+import com.miml.c2k.domain.movie.Movie;
+import com.miml.c2k.domain.payment.Payment;
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.theater.Theater;
+import java.time.LocalDateTime;
+
+public record TicketInfoResponseDto(String movieTitle,
+                                    String poster,
+                                    String theaterName,
+                                    LocalDateTime startTime,
+                                    int screenNum,
+                                    long paymentFee) {
+
+    public TicketInfoResponseDto create(Movie movie, Theater theater, Schedule schedule, Screen screen, Payment payment) {
+        return new TicketInfoResponseDto(movie.getTitle(),
+            movie.getPoster(),
+            theater.getName(),
+            schedule.getStartTime(),
+            screen.getNum(),
+            payment.getAmount());
+    }
+}

--- a/src/main/java/com/miml/c2k/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/repository/TicketRepository.java
@@ -13,7 +13,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     @Query(value = "SELECT t FROM Ticket t WHERE t.member.id = :memberId")
     List<Ticket> findAllByMemberId(Long memberId);
 
-    @Query(value = "SELECT s FROM Schedule s JOIN Ticket t ON s.id = t.schedule.id WHERE t.id = :ticketId")
+    @Query(value = "SELECT sch FROM Schedule sch JOIN Ticket t ON sch.id = t.schedule.id WHERE t.id = :ticketId")
     Optional<Schedule> findScheduleByTicketId(Long ticketId);
 
     @Query(value = "SELECT p FROM Payment p JOIN Ticket t ON p.id = t.payment.id WHERE t.id = :ticketId")

--- a/src/main/java/com/miml/c2k/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/repository/TicketRepository.java
@@ -1,5 +1,6 @@
 package com.miml.c2k.domain.ticket.repository;
 
+import com.miml.c2k.domain.payment.Payment;
 import com.miml.c2k.domain.schedule.Schedule;
 import com.miml.c2k.domain.ticket.Ticket;
 import java.util.List;
@@ -14,4 +15,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     @Query(value = "SELECT s FROM Schedule s JOIN Ticket t ON s.id = t.schedule.id WHERE t.id = :ticketId")
     Optional<Schedule> findScheduleByTicketId(Long ticketId);
+
+    @Query(value = "SELECT p FROM Payment p JOIN Ticket t ON p.id = t.payment.id WHERE t.id = :ticketId")
+    Optional<Payment> findPaymentByTicketId(Long ticketId);
 }

--- a/src/main/java/com/miml/c2k/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/repository/TicketRepository.java
@@ -1,8 +1,17 @@
 package com.miml.c2k.domain.ticket.repository;
 
+import com.miml.c2k.domain.schedule.Schedule;
 import com.miml.c2k.domain.ticket.Ticket;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
+    @Query(value = "SELECT t FROM Ticket t WHERE t.member.id = :memberId")
+    List<Ticket> findAllByMemberId(Long memberId);
+
+    @Query(value = "SELECT s FROM Schedule s JOIN Ticket t ON s.id = t.schedule.id WHERE t.id = :ticketId")
+    Optional<Schedule> findScheduleByTicketId(Long ticketId);
 }

--- a/src/main/java/com/miml/c2k/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/service/TicketService.java
@@ -1,0 +1,61 @@
+package com.miml.c2k.domain.ticket.service;
+
+import com.miml.c2k.domain.movie.Movie;
+import com.miml.c2k.domain.payment.Payment;
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.theater.Theater;
+import com.miml.c2k.domain.theater.repository.TheaterRepository;
+import com.miml.c2k.domain.ticket.Ticket;
+import com.miml.c2k.domain.ticket.dto.TicketInfoResponseDto;
+import com.miml.c2k.domain.ticket.repository.TicketRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final TheaterRepository theaterRepository;
+
+    public List<TicketInfoResponseDto> getAllTicketsInfoByMemberId(Long memberId) {
+        List<TicketInfoResponseDto> ticketInfoResponseDtos = new ArrayList<>();
+
+        List<Ticket> tickets = ticketRepository.findAllByMemberId(memberId);
+
+        tickets.parallelStream()
+            .forEach(ticket -> addTicketInfoResponseDtosByTicket(ticket, ticketInfoResponseDtos));
+
+        return ticketInfoResponseDtos;
+    }
+
+    private void addTicketInfoResponseDtosByTicket(Ticket ticket,
+        List<TicketInfoResponseDto> ticketInfoResponseDtos) {
+        // TODO: 추후 비동기 처리
+        Schedule relatedSchedule = ticketRepository.findScheduleByTicketId(ticket.getId())
+            .orElseThrow(() -> new RuntimeException("연결된 상영 일정 없음")); // TODO: 사용자 정의 예외 생성
+
+        Movie relatedMovie = scheduleRepository.findMovieByScheduleId(relatedSchedule.getId())
+            .orElseThrow(() -> new RuntimeException("연결된 영화 없음")); // TODO: 사용자 정의 예외 생성
+
+        Screen relatedScreen = scheduleRepository.findScreenByScheduleId(relatedSchedule.getId())
+            .orElseThrow(() -> new RuntimeException("연결된 상영관 없음"));// TODO: 사용자 정의 예외 생성
+
+        Theater relatedTheater = theaterRepository.findByScreenId(relatedScreen.getId())
+            .orElseThrow(() -> new RuntimeException("연결된 영화관 없음"));// TODO: 사용자 정의 예외 생성
+
+        Payment relatedPayment = ticketRepository.findPaymentByTicketId(ticket.getId())
+            .orElseGet(Payment::new);
+
+        TicketInfoResponseDto ticketInfoResponseDto = TicketInfoResponseDto.create(relatedMovie,
+            relatedTheater,
+            relatedSchedule, relatedScreen, relatedPayment);
+
+        ticketInfoResponseDtos.add(ticketInfoResponseDto);
+    }
+}

--- a/src/main/java/com/miml/c2k/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/service/TicketService.java
@@ -5,6 +5,8 @@ import com.miml.c2k.domain.payment.Payment;
 import com.miml.c2k.domain.schedule.Schedule;
 import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
 import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.seat.Seat;
+import com.miml.c2k.domain.seat.repository.SeatRepository;
 import com.miml.c2k.domain.theater.Theater;
 import com.miml.c2k.domain.theater.repository.TheaterRepository;
 import com.miml.c2k.domain.ticket.Ticket;
@@ -22,6 +24,7 @@ public class TicketService {
     private final TicketRepository ticketRepository;
     private final ScheduleRepository scheduleRepository;
     private final TheaterRepository theaterRepository;
+    private final SeatRepository seatRepository;
 
     public List<TicketInfoResponseDto> getAllTicketsInfoByMemberId(Long memberId) {
         List<TicketInfoResponseDto> ticketInfoResponseDtos = new ArrayList<>();
@@ -49,12 +52,14 @@ public class TicketService {
         Theater relatedTheater = theaterRepository.findByScreenId(relatedScreen.getId())
             .orElseThrow(() -> new RuntimeException("연결된 영화관 없음"));// TODO: 사용자 정의 예외 생성
 
+        List<Seat> relatedSeats = seatRepository.findAllByTicketId(ticket.getId());
+
         Payment relatedPayment = ticketRepository.findPaymentByTicketId(ticket.getId())
             .orElseGet(Payment::new);
 
         TicketInfoResponseDto ticketInfoResponseDto = TicketInfoResponseDto.create(relatedMovie,
             relatedTheater,
-            relatedSchedule, relatedScreen, relatedPayment);
+            relatedSchedule, relatedScreen, relatedPayment, relatedSeats);
 
         ticketInfoResponseDtos.add(ticketInfoResponseDto);
     }

--- a/src/main/resources/templates/myPage/myPage.html
+++ b/src/main/resources/templates/myPage/myPage.html
@@ -59,6 +59,23 @@
     </div>
   </div>
 </div>
+<div>
+  <div class="container" th:each="ticket : ${ticketInfoResponseDtos}">
+    <img th:src="@{'/' + ${ticket.poster()}}" alt="포스터">
+    <p th:text="${ticket.movieTitle()}"></p>
+    <p th:text="${ticket.screenNum()} + '관'"></p>
+    <p th:text="${ticket.theaterName()}"></p>
+    <p th:text="${#temporals.format(ticket.startTime(), 'yyyy-MM-dd HH:mm')}"></p>
+    <div th:each="seat : ${ticket.seats()}">
+      <span th:text="${seat} + ' '"></span>
+    </div>
+    <p th:text="${ticket.paymentFee()}"></p>
+  </div>
+</div>
+
+<script>
+
+</script>
 
 <!-- Include Bootstrap JS dependencies: jQuery and Popper.js -->
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #18 
"/myPage"에서 회원 정보를 보여줌과 동시에 예매 정보도 보여집니다.

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 티켓과 연관된 영화, 영화관, 상영관, 좌석, 결제를 가져오는 로직과 쿼리가 추가되어 있습니다.
![image](https://github.com/Ogu-Family/MIML_backend/assets/76583883/2f64849c-738c-4116-8d4a-a7bf24241a48)
(사진 깨진건 로컬에 저장된 html이라 그렇습니다)

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
쿼리 부분 확인해 주시고, `TicketService`에서 엄청나게 가져오는데, 가독성 면이나 아니면 성능 측에서 더 좋은 방법이 있다면 말씀주세요~