### PR TITLE
Feat/#30 관리자 상영 일정 단위 테스트 추가

### DIFF
--- a/src/main/java/com/miml/c2k/domain/schedule/Schedule.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/Schedule.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -44,10 +45,13 @@ public class Schedule {
     @JoinColumn(name = "movie_id")
     private Movie movie;
 
-    public Schedule(LocalDateTime startTime, LocalDateTime endTime) {
+    @Builder
+    public Schedule(LocalDateTime startTime, LocalDateTime endTime, Screen screen, Movie movie) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.fee = calculateFee();
+        this.screen = screen;
+        this.movie = movie;
     }
 
     public void updateScreen(Screen screen) {

--- a/src/main/java/com/miml/c2k/domain/schedule/dto/ScheduleSavingDto.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/dto/ScheduleSavingDto.java
@@ -21,6 +21,9 @@ public class ScheduleSavingDto {
     }
 
     public Schedule toEntity() {
-        return new Schedule(startTime, endTime);
+        return Schedule.builder().
+            startTime(startTime).
+            endTime(endTime)
+            .build();
     }
 }

--- a/src/main/java/com/miml/c2k/domain/screen/Screen.java
+++ b/src/main/java/com/miml/c2k/domain/screen/Screen.java
@@ -9,10 +9,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Screen {
 
     @Id
@@ -28,4 +32,11 @@ public class Screen {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theater_id")
     private Theater theater;
+
+    @Builder
+    public Screen(Integer num, Integer seatCount, Theater theater) {
+        this.num = num;
+        this.seatCount = seatCount;
+        this.theater = theater;
+    }
 }

--- a/src/test/java/com/miml/c2k/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/miml/c2k/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,72 @@
+package com.miml.c2k.domain.admin.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.miml.c2k.domain.admin.dto.MovieAdminResponseDto;
+import com.miml.c2k.domain.movie.Movie;
+import com.miml.c2k.domain.movie.service.MovieService;
+import com.miml.c2k.domain.schedule.service.ScheduleService;
+import com.miml.c2k.global.auth.SecurityConfig;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AdminController.class)
+@Import(SecurityConfig.class)
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MovieService movieService;
+    @MockBean
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("관리자 상영 일정 추가 페이지를 보여줄 수 있다.")
+    void success_show_page_adding_schedule() throws Exception {
+        List<MovieAdminResponseDto> dtos = new ArrayList<>();
+        dtos.add(MovieAdminResponseDto.create(
+            Movie.builder().title("영화1").code("1004").genre("스릴러").nation("KR").director("킴남규")
+                .openDate(LocalDate.now()).build()));
+        dtos.add(MovieAdminResponseDto.create(
+            Movie.builder().title("영화2").code("1005").genre("스릴러").nation("KR").director("초이정은")
+                .openDate(LocalDate.now()).build()));
+
+        when(movieService.getAllMovies()).thenReturn(dtos);
+
+        mockMvc.perform(get("/admin/schedules"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("movieAdminResponseDtos", dtos));
+
+        verify(movieService).getAllMovies();
+    }
+
+    @Test
+    @DisplayName("관리자가 상영 일정을 정상적으로 추가할 수 있다.")
+    void success_post_request_to_add_schedule() throws Exception {
+        mockMvc.perform(
+                post("/admin/schedules")
+                    .param("movieId", "1")
+                    .param("screenId", "1")
+                    .param("startTime", LocalDateTime.now().toString())
+                    .param("endTime", LocalDateTime.now().toString()))
+            .andExpect(status().is3xxRedirection())
+            .andDo(print());
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/schedule/ScheduleTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/ScheduleTest.java
@@ -1,0 +1,27 @@
+package com.miml.c2k.domain.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ScheduleTest {
+
+    private static final int EARLY_MORNING_FEE = 8_000;
+    private static final int NORMAL_FEE = 12_000;
+
+    @Test
+    @DisplayName("상영 일정이 시간 대에 맞는 적절한 금액으로 책정된다.")
+    void success_making_schedule_to_have_correct_fee() {
+        Schedule earlyMorningSchedule = Schedule.builder()
+            .startTime(LocalDateTime.of(2024, 1, 1, 9, 59))
+            .build();
+        Schedule justSchedule = Schedule.builder()
+            .startTime(LocalDateTime.of(2024, 1, 1, 10, 0))
+            .build();
+
+        assertThat(earlyMorningSchedule.getFee()).isEqualTo(EARLY_MORNING_FEE);
+        assertThat(justSchedule.getFee()).isEqualTo(NORMAL_FEE);
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/schedule/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/repository/ScheduleRepositoryTest.java
@@ -2,10 +2,6 @@ package com.miml.c2k.domain.schedule.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
-import com.miml.c2k.domain.schedule.Schedule;
-import com.miml.c2k.domain.screen.Screen;
-import com.miml.c2k.domain.screen.repository.ScreenRepository;
 import com.miml.c2k.domain.movie.Movie;
 import com.miml.c2k.domain.movie.repository.MovieRepository;
 import com.miml.c2k.domain.schedule.Schedule;

--- a/src/test/java/com/miml/c2k/domain/schedule/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/repository/ScheduleRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.miml.c2k.domain.schedule.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ScheduleRepositoryTest {
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+    @Autowired
+    private ScreenRepository screenRepository;
+
+    @Test
+    @DisplayName("countAllByScreenIdBetweenTimeline 메서드 쿼리로 startTime, endTime 사이 상영 일정 개수를 정확히 셀 수 있다.")
+    void success_count_all_by_screen_id_between_timeline() {
+        // given
+        Screen screen = Screen.builder().seatCount(20).num(1).build();
+
+        Schedule schedule1 = Schedule.builder().screen(screen)
+            .startTime(LocalDateTime.of(2024, 1, 8, 21, 0))
+            .endTime(LocalDateTime.of(2024, 1, 8, 22, 30)).build();
+        Schedule schedule2 = Schedule.builder().screen(screen)
+            .startTime(LocalDateTime.of(2024, 1, 8, 22, 50))
+            .endTime(LocalDateTime.of(2024, 1, 8, 23, 55)).build();
+
+        screenRepository.save(screen);
+        scheduleRepository.saveAll(List.of(schedule1, schedule2));
+
+        // when
+        int scheduleCountBetween22To23 = scheduleRepository.countAllByScreenIdBetweenTimeline(schedule1.getId(),
+            LocalDateTime.of(2024, 1, 8, 22, 0), LocalDateTime.of(2024, 1, 8, 23, 0));
+        int scheduleCountBetween23To24 = scheduleRepository.countAllByScreenIdBetweenTimeline(schedule1.getId(),
+            LocalDateTime.of(2024, 1, 8, 23, 0), LocalDateTime.of(2024, 1, 9, 0, 0));
+
+        assertThat(scheduleCountBetween22To23).isEqualTo(2);
+        assertThat(scheduleCountBetween23To24).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/service/ScheduleServiceTest.java
@@ -1,0 +1,81 @@
+package com.miml.c2k.domain.schedule.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.miml.c2k.domain.movie.Movie;
+import com.miml.c2k.domain.movie.repository.MovieRepository;
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.schedule.dto.ScheduleSavingDto;
+import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import com.miml.c2k.domain.seat.repository.SeatRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private MovieRepository movieRepository;
+    @Mock
+    private ScreenRepository screenRepository;
+    @Mock
+    private SeatRepository seatRepository;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("saveSchedule 메서드가 정상적인 ScheduleSavingDto 객체에 한해 잘 실행되는지 확인한다.")
+    void success_save_schedule_given_normal_input() throws Exception{
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = LocalDateTime.now();
+
+        ScheduleSavingDto scheduleSavingDto = new ScheduleSavingDto(1L, 1L, startTime, endTime);
+
+        Movie retrievedMovie = Movie.builder().title("temp").build();
+        Field movieId = retrievedMovie.getClass().getDeclaredField("id");
+        movieId.setAccessible(true);
+        movieId.set(retrievedMovie, 1L);
+
+        Screen retrievedScreen = Screen.builder().num(1).build();
+        Field screenId = retrievedScreen.getClass().getDeclaredField("id");
+        screenId.setAccessible(true);
+        screenId.set(retrievedScreen, 1L);
+
+        when(movieRepository.findById(1L))
+            .thenReturn(Optional.of(retrievedMovie));
+        when(screenRepository.findById(1L))
+            .thenReturn(Optional.of(retrievedScreen));
+
+        scheduleService.saveSchedule(scheduleSavingDto);
+
+        verify(movieRepository).findById(1L);
+        verify(screenRepository).findById(1L);
+        verify(scheduleRepository).save(any(Schedule.class));
+    }
+
+    @Test
+    @DisplayName("시작 시간이 끝 시간보다 뒤인 모순된 입력에 대해 saveSchedule 메서드가 예외를 발생시킨다.")
+    void fail_save_schedule_given_abnormal_input() {
+        LocalDateTime startTime = LocalDateTime.of(2024, 1, 26, 5, 30);
+        LocalDateTime endTime = LocalDateTime.of(2024, 1, 1, 5, 30);
+
+        ScheduleSavingDto scheduleSavingDto = new ScheduleSavingDto(1L, 1L, startTime, endTime);
+
+        assertThrows(RuntimeException.class,
+            () -> scheduleService.saveSchedule(scheduleSavingDto));
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/service/ScheduleServiceTest.java
@@ -69,7 +69,7 @@ class ScheduleServiceTest {
 
     @Test
     @DisplayName("시작 시간이 끝 시간보다 뒤인 모순된 입력에 대해 saveSchedule 메서드가 예외를 발생시킨다.")
-    void fail_save_schedule_given_abnormal_input() {
+    void fail_save_schedule_given_abnormal_timeline_input() {
         LocalDateTime startTime = LocalDateTime.of(2024, 1, 26, 5, 30);
         LocalDateTime endTime = LocalDateTime.of(2024, 1, 1, 5, 30);
 
@@ -77,5 +77,21 @@ class ScheduleServiceTest {
 
         assertThrows(RuntimeException.class,
             () -> scheduleService.saveSchedule(scheduleSavingDto));
+    }
+
+    @Test
+    @DisplayName("상영하려는 시간 대에 해당 상영관에서 이미 상영 중인 영화가 있다면 예외를 발생시킨다.")
+    void fail_save_schedule_given_any_schedules_already_exist_in_timeline() {
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = startTime.plusHours(2);
+
+        ScheduleSavingDto scheduleSavingDto = new ScheduleSavingDto(1L, 2L, startTime, endTime);
+
+        when(scheduleRepository.countAllByScreenIdBetweenTimeline(2L, startTime, endTime))
+            .thenReturn(2);
+
+        assertThrows(RuntimeException.class, () -> scheduleService.saveSchedule(scheduleSavingDto));
+
+        verify(scheduleRepository).countAllByScreenIdBetweenTimeline(2L, startTime, endTime);
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #30 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
다음 테스트 코드를 작성했습니다.
- 상영 일정을 보여주는 테스트
- 상영 일정을 삽입하는 테스트
- 상영 일정이 적절한 가격을 가지는지 확인하는 테스트

다음이 추가되어 있습니다.
- `Screen`, `Schedule` 도메인에 대한 `@Builder`

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
놓친 엣지 케이스 혹은 상황이 있다면 알려주시면 감사하겠습니다.