### PR TITLE
Feat/#29 영화 예매 페이지와 연관된 모든 테스트 코드 추가

### DIFF
--- a/src/main/java/com/miml/c2k/domain/movie/Movie.java
+++ b/src/main/java/com/miml/c2k/domain/movie/Movie.java
@@ -35,7 +35,7 @@ public class Movie {
     private String poster;
 
     @Column(name = "audience_count", nullable = false, columnDefinition = "int default 0")
-    private Long audienceCount = 0L;
+    private long audienceCount = 0L;
 
     @Column(name = "code", nullable = false, unique = true)
     private String code;
@@ -44,12 +44,13 @@ public class Movie {
     private LocalDate openDate;
 
     @Builder
-    public Movie(String title, String director, String genre, String nation, String code,
+    public Movie(String title, String director, String genre, String nation, long audienceCount, String code,
             LocalDate openDate) {
         this.title = title;
         this.director = director;
         this.genre = genre;
         this.nation = nation;
+        this.audienceCount = audienceCount;
         this.code = code;
         this.openDate = openDate;
     }

--- a/src/main/java/com/miml/c2k/domain/seat/service/SeatService.java
+++ b/src/main/java/com/miml/c2k/domain/seat/service/SeatService.java
@@ -80,7 +80,7 @@ public class SeatService {
                 .orElseThrow(() -> new RuntimeException("해당 좌석 없음."));
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("가입되지 않은 회원"));
-        Ticket ticket = ticketRepository.save(Ticket.createWithoutPayment(member, schedule));
+        Ticket ticket = ticketRepository.save(Ticket.builder().member(member).schedule(schedule).build());
 
         List<Seat> reservedSeats = seatRequestDto.getSeatNameTypes().stream()
                 .map(seatNameType -> seatRepository.save(

--- a/src/main/java/com/miml/c2k/domain/theater/Theater.java
+++ b/src/main/java/com/miml/c2k/domain/theater/Theater.java
@@ -5,10 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Theater {
 
     @Id
@@ -17,4 +21,9 @@ public class Theater {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Builder
+    public Theater(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/miml/c2k/domain/theater/controller/TheaterController.java
+++ b/src/main/java/com/miml/c2k/domain/theater/controller/TheaterController.java
@@ -2,8 +2,10 @@ package com.miml.c2k.domain.theater.controller;
 
 import com.miml.c2k.domain.theater.dto.TheaterAdminResponseDto;
 import com.miml.c2k.domain.theater.service.TheaterService;
+import com.miml.c2k.global.dto.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,7 +16,7 @@ public class TheaterController {
     private final TheaterService theaterService;
 
     @GetMapping("/api/v1/theaters")
-    public List<TheaterAdminResponseDto> getAllTheaters() {
-        return theaterService.getAllTheaters();
+    public ApiResponse<List<TheaterAdminResponseDto>> getAllTheaters() {
+        return ApiResponse.create(HttpStatus.SC_OK, "영화 목록 정상 반환", theaterService.getAllTheaters());
     }
 }

--- a/src/main/java/com/miml/c2k/domain/theater/controller/TheaterController.java
+++ b/src/main/java/com/miml/c2k/domain/theater/controller/TheaterController.java
@@ -17,6 +17,6 @@ public class TheaterController {
 
     @GetMapping("/api/v1/theaters")
     public ApiResponse<List<TheaterAdminResponseDto>> getAllTheaters() {
-        return ApiResponse.create(HttpStatus.SC_OK, "영화 목록 정상 반환", theaterService.getAllTheaters());
+        return ApiResponse.create(HttpStatus.SC_OK, "영화관 목록 정상 반환", theaterService.getAllTheaters());
     }
 }

--- a/src/main/java/com/miml/c2k/domain/ticket/Ticket.java
+++ b/src/main/java/com/miml/c2k/domain/ticket/Ticket.java
@@ -20,6 +20,7 @@ import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -51,15 +52,12 @@ public class Ticket {
     @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL)
     private final List<Seat> seats = new ArrayList<>();
 
+    @Builder
     private Ticket(Member member, Schedule schedule, Payment payment) {
         this.status = TicketStatus.ACTIVE; // TODO: 결제 구현 후에는, BEFORE_PAYMENT 상태가 기본 값이 되도록 해야 함.
         this.member = member;
         this.schedule = schedule;
         this.payment = payment;
-    }
-
-    public static Ticket createWithoutPayment(Member member, Schedule schedule) {
-        return new Ticket(member, schedule, null);
     }
 
     public void addSeat(Seat seat) {

--- a/src/main/resources/templates/schedule/select-schedule.html
+++ b/src/main/resources/templates/schedule/select-schedule.html
@@ -45,7 +45,7 @@
       document.querySelector("#schedules")
     ];
 
-    if (!movieSelect.value || !theaterSelector.value || !dateSelect.value) {
+    if (!movieSelect.value || !theaterSelector.value || !dateSelect.value || !seatCountInput.value) {
       toastPopUp("모든 값을 입력해 주세요!");
       return;
     }
@@ -112,10 +112,10 @@
   const loadTheaters = async () => {
     return await fetch("/api/v1/theaters")
     .then(res => { return res.json(); })
-    .then(data => {
-      console.log(data);
+    .then(res => {
+      console.log(res.data);
 
-      data.forEach(theater => {
+      res.data.forEach(theater => {
         const theaterOption = document.createElement("option");
 
         theaterOption.value = theater.id;

--- a/src/test/java/com/miml/c2k/domain/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/controller/ScheduleControllerTest.java
@@ -1,0 +1,88 @@
+package com.miml.c2k.domain.schedule.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.miml.c2k.domain.schedule.dto.ScheduleViewResponseDto;
+import com.miml.c2k.domain.schedule.service.ScheduleService;
+import com.miml.c2k.global.auth.SecurityConfig;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ScheduleController.class)
+@AutoConfigureRestDocs
+@Import(SecurityConfig.class)
+class ScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("영화 상영 선택 페이지를 볼 수 있다.")
+    void success_show_schedule_page() throws Exception {
+        mockMvc.perform(get("/schedules"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("주어진 정보들을 이용해 상영 일정을 가져올 수 있다.")
+    void success_get_schedules_by_infos() throws Exception {
+        List<ScheduleViewResponseDto> scheduleViewResponseDtos = new ArrayList<>();
+        LocalDate nowLocalDate = LocalDate.now();
+
+        ScheduleViewResponseDto data1 = new ScheduleViewResponseDto(1L, 2, 100, 80,
+            nowLocalDate.atTime(1, 0), nowLocalDate.atTime(3, 0), 1000);
+        ScheduleViewResponseDto data2 = new ScheduleViewResponseDto(2L, 2, 100, 90,
+            nowLocalDate.atTime(5, 0), nowLocalDate.atTime(7, 0), 1000);
+
+        scheduleViewResponseDtos.add(data1);
+        scheduleViewResponseDtos.add(data2);
+
+        when(scheduleService.getSchedulesBy(1L, 2L, nowLocalDate))
+            .thenReturn(scheduleViewResponseDtos);
+
+        mockMvc.perform(get("/api/v1/schedules")
+                .param("movieId", "1")
+                .param("theaterId", "2")
+                .param("date", nowLocalDate.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data[0].id").value(1L))
+            .andExpect(jsonPath("$.data[0].screenNum").value(2))
+            .andExpect(jsonPath("$.data[1].id").value(2L))
+            .andDo(print())
+            .andDo(document("getSchedulesBy",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").type(NUMBER).description("처리 코드"),
+                    fieldWithPath("message").type(STRING).description("처리 메시지"),
+                    fieldWithPath("data[]").type(ARRAY).description("가져온 상영 일정 리스트"),
+                    fieldWithPath("data[].id").type(NUMBER).description("상영 일정 id"),
+                    fieldWithPath("data[].screenNum").type(NUMBER).description("상영관 번호"),
+                    fieldWithPath("data[].totalSeatsCount").type(NUMBER).description("상영관 전체 좌석 수"),
+                    fieldWithPath("data[].availableSeatsCount").type(NUMBER).description("상영관 가용 좌석 수"),
+                    fieldWithPath("data[].startTime").type(STRING).description("상영 시작 시간"),
+                    fieldWithPath("data[].endTime").type(STRING).description("상영 끝나는 시간"),
+                    fieldWithPath("data[].fee").type(NUMBER).description("가격")
+                )));
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/schedule/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/repository/ScheduleRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.miml.c2k.domain.schedule.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.miml.c2k.domain.movie.Movie;
+import com.miml.c2k.domain.movie.repository.MovieRepository;
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import com.miml.c2k.domain.theater.Theater;
+import com.miml.c2k.domain.theater.repository.TheaterRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE) // TODO: 이 부분 상의
+class ScheduleRepositoryTest {
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private MovieRepository movieRepository;
+
+    @Autowired
+    private ScreenRepository screenRepository;
+
+    @Autowired
+    private TheaterRepository theaterRepository;
+
+    @Test
+    @DisplayName("특정 날짜, 영화, 영화관에 해당하는 상영 일정을 전부 가져온다.")
+    void success_find_all_by_movie_id_and_theater_id_and_date() {
+        Movie movie = Movie.builder().title("title").code("1204").audienceCount(12392L).build();
+        movieRepository.save(movie);
+
+        Theater theater1 = Theater.builder().name("theater1").build();
+        Theater theater2 = Theater.builder().name("theater2").build();
+        theaterRepository.saveAll(List.of(theater1, theater2));
+
+        Screen screen1 = Screen.builder().num(1).seatCount(20).theater(theater1).build();
+        Screen screen2 = Screen.builder().num(2).seatCount(30).theater(theater1).build();
+        Screen screen3 = Screen.builder().num(2).seatCount(30).theater(theater2).build();
+        screenRepository.saveAll(List.of(screen1, screen2, screen3));
+
+        LocalDateTime startTime = LocalDateTime.of(2024, 1, 1, 5, 30);
+        LocalDateTime endTime = LocalDateTime.of(2024, 1, 1, 7, 30);
+
+        Schedule schedule1 = Schedule.builder().startTime(startTime).endTime(endTime)
+            .movie(movie).screen(screen1)
+            .build();
+        Schedule schedule2 = Schedule.builder().startTime(startTime).endTime(endTime)
+            .movie(movie).screen(screen2)
+            .build();
+        Schedule schedule3 = Schedule.builder().startTime(startTime).endTime(endTime)
+            .movie(movie).screen(screen3)
+            .build();
+        scheduleRepository.saveAll(List.of(schedule1, schedule2, schedule3));
+
+        List<Schedule> retrievedSchedules = scheduleRepository.findAllByMovieIdAndTheaterIdAndDate(
+            movie.getId(), theater1.getId(), startTime.toLocalDate());
+
+        assertThat(retrievedSchedules).hasSize(2);
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/miml/c2k/domain/schedule/service/ScheduleServiceTest.java
@@ -1,0 +1,88 @@
+package com.miml.c2k.domain.schedule.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.miml.c2k.domain.movie.repository.MovieRepository;
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.schedule.dto.ScheduleViewResponseDto;
+import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import com.miml.c2k.domain.seat.repository.SeatRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private MovieRepository movieRepository;
+    @Mock
+    private ScreenRepository screenRepository;
+    @Mock
+    private SeatRepository seatRepository;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("받아온 영화 id, 영화관 id, 선택된 날짜에 해당하는 상영 일정들을 가져온다.")
+    void success_get_schedules_by_infos() throws Exception {
+        // given
+        LocalDate nowLocalDate = LocalDate.now();
+
+        List<Schedule> schedules = new ArrayList<>();
+
+        Screen screen = Screen.builder().seatCount(25).build();
+
+        Schedule testSchedule1 = Schedule.builder()
+            .startTime(nowLocalDate.atTime(12, 0))
+            .endTime(nowLocalDate.atTime(14, 0))
+            .screen(screen)
+            .build();
+        Schedule testSchedule2 = Schedule.builder()
+            .startTime(nowLocalDate.atTime(12, 0))
+            .endTime(nowLocalDate.atTime(14, 0))
+            .screen(screen)
+            .build();
+
+        Field scheduleIdField = Schedule.class.getDeclaredField("id");
+
+        scheduleIdField.setAccessible(true);
+        scheduleIdField.set(testSchedule1, 1L);
+        scheduleIdField.set(testSchedule2, 2L);
+
+        schedules.add(testSchedule1);
+        schedules.add(testSchedule2);
+
+        when(scheduleRepository.findAllByMovieIdAndTheaterIdAndDate(1L, 1L, nowLocalDate))
+            .thenReturn(schedules);
+        when(seatRepository.countReservedSeatsByScheduleId(any(Long.class)))
+            .thenReturn(20);
+
+        // when
+        List<ScheduleViewResponseDto> scheduleViewResponseDtos = scheduleService.getSchedulesBy(1L,
+            1L, nowLocalDate);
+
+        // then
+        assertThat(scheduleViewResponseDtos).hasSize(2);
+        assertThat(scheduleViewResponseDtos.get(0).getAvailableSeatsCount()).isEqualTo(5);
+
+        verify(scheduleRepository).findAllByMovieIdAndTheaterIdAndDate(1L, 1L, nowLocalDate);
+        verify(seatRepository, times(2)).countReservedSeatsByScheduleId(any());
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/seat/repository/SeatRepositoryTest.java
+++ b/src/test/java/com/miml/c2k/domain/seat/repository/SeatRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.miml.c2k.domain.seat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.miml.c2k.domain.schedule.Schedule;
+import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
+import com.miml.c2k.domain.seat.Seat;
+import com.miml.c2k.domain.seat.Seat.SeatNameType;
+import com.miml.c2k.domain.ticket.Ticket;
+import com.miml.c2k.domain.ticket.repository.TicketRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE) // TODO: 이 부분 상의
+class SeatRepositoryTest {
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Test
+    @DisplayName("상영 일자 id를 이용해 해당 상영 일정의 예약된 좌석 수를 가져온다.")
+    void success_count_reserved_seats_by_schedule_id() {
+        // given
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = startTime.plusHours(2);
+
+        Schedule savedSchedule = scheduleRepository.save(
+            Schedule.builder().startTime(startTime).endTime(endTime).build());
+
+        Ticket ticket1 = Ticket.builder().schedule(savedSchedule).build();
+        Ticket ticket2 = Ticket.builder().schedule(savedSchedule).build();
+
+        Seat seat1 = Seat.builder().name(SeatNameType.J10).build();
+        Seat seat2 = Seat.builder().name(SeatNameType.J11).build();
+        Seat seat3 = Seat.builder().name(SeatNameType.J12).build();
+
+        ticket1.addSeat(seat1);
+        ticket1.addSeat(seat2);
+        ticket2.addSeat(seat3);
+
+        ticketRepository.saveAll(List.of(ticket1, ticket2));
+
+        // when
+        int reservedSeatCount = seatRepository.countReservedSeatsByScheduleId(savedSchedule.getId());
+
+        // then
+        assertThat(reservedSeatCount).isEqualTo(3);
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/theater/controller/TheaterControllerTest.java
+++ b/src/test/java/com/miml/c2k/domain/theater/controller/TheaterControllerTest.java
@@ -1,0 +1,82 @@
+package com.miml.c2k.domain.theater.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.miml.c2k.domain.theater.Theater;
+import com.miml.c2k.domain.theater.dto.TheaterAdminResponseDto;
+import com.miml.c2k.domain.theater.service.TheaterService;
+import com.miml.c2k.global.auth.SecurityConfig;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = TheaterController.class)
+@AutoConfigureRestDocs
+@Import(SecurityConfig.class)
+class TheaterControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TheaterService theaterService;
+
+    @Test
+    @DisplayName("모든 영화관 목록을 반환한다.")
+    void success_get_all_theaters() throws Exception {
+        // given
+        Field theaterIdField = Theater.class.getDeclaredField("id");
+        theaterIdField.setAccessible(true);
+        long idValue = 1L;
+
+        Theater theater1 = Theater.builder().name("1").build();
+        Theater theater2 = Theater.builder().name("2").build();
+        List<Theater> theaters = List.of(theater1, theater2);
+
+        for (Theater theater : theaters) {
+            theaterIdField.set(theater, idValue++);
+        }
+
+        List<TheaterAdminResponseDto> theaterAdminResponseDtos = theaters.stream()
+            .map(TheaterAdminResponseDto::create).toList();
+
+        when(theaterService.getAllTheaters()).thenReturn(theaterAdminResponseDtos);
+
+        // when
+        mockMvc.perform(get("/api/v1/theaters").characterEncoding(StandardCharsets.UTF_8))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.message").value("영화관 목록 정상 반환"))
+            .andExpect(jsonPath("$.data.size()").value(2))
+            .andDo(print())
+            .andDo(document("getAllTheaters", preprocessResponse(prettyPrint()), responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER).description("처리 코드"),
+                fieldWithPath("message").type(JsonFieldType.STRING).description("처리 메시지"),
+                fieldWithPath("data[]").type(JsonFieldType.ARRAY).description("영화관 목록"),
+                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("영화관 id"),
+                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("영화관 이름")
+            )));
+
+        // then
+        verify(theaterService).getAllTheaters();
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #29 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
다음은 변경 사항입니다.
- `Ticket`과 `Theater`가 빌더 패턴을 사용하도록 변경했습니다.

다음 테스트 코드를 구현했습니다.
- 사용자가 영화 상영 일정 선택 페이지를 볼 수 있다.
- 영화 id, 영화관 id, 날짜로 상영 일정을 가져올 수 있다.
- 특정 상영 일정의 예약된 좌석 개수를 가져올 수 있다.
- 모든 영화관 목록을 가져오는 API가 정상 반환한다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
어색하다고 느껴지는 부분이 있으면 말씀 주세요!