### PR TITLE
Feat/#41, #42 좌석 동시 예매 불가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -43,6 +45,7 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
     testImplementation 'com.h2database:h2'
+
     
 }
 

--- a/src/main/java/com/miml/c2k/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/service/ScheduleService.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class ScheduleService {
     private final ScreenRepository screenRepository;
     private final SeatRepository seatRepository;
 
+    @Transactional
     public void saveSchedule(ScheduleSavingDto scheduleSavingDto) {
         validateNewSchedule(scheduleSavingDto);
 
@@ -39,11 +41,13 @@ public class ScheduleService {
         schedule.updateMovie(movie);
         schedule.updateScreen(screen);
 
+        scheduleRepository.save(schedule);
+
         Arrays.stream(SeatNameType.values()).forEach(seatNameType ->
             seatRepository.save(Seat.builder().name(seatNameType).schedule(schedule).screen(screen).build()));
-        scheduleRepository.save(schedule);
     }
 
+    @Transactional
     public List<ScheduleViewResponseDto> getSchedulesBy(Long movieId, Long theaterId,
         LocalDate date) {
         List<Schedule> allSchedules = scheduleRepository.findAllByMovieIdAndTheaterIdAndDate(

--- a/src/main/java/com/miml/c2k/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/miml/c2k/domain/schedule/service/ScheduleService.java
@@ -8,9 +8,12 @@ import com.miml.c2k.domain.schedule.dto.ScheduleViewResponseDto;
 import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
 import com.miml.c2k.domain.screen.Screen;
 import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import com.miml.c2k.domain.seat.Seat;
+import com.miml.c2k.domain.seat.Seat.SeatNameType;
 import com.miml.c2k.domain.seat.repository.SeatRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +39,8 @@ public class ScheduleService {
         schedule.updateMovie(movie);
         schedule.updateScreen(screen);
 
+        Arrays.stream(SeatNameType.values()).forEach(seatNameType ->
+            seatRepository.save(Seat.builder().name(seatNameType).schedule(schedule).screen(screen).build()));
         scheduleRepository.save(schedule);
     }
 

--- a/src/main/java/com/miml/c2k/domain/seat/Seat.java
+++ b/src/main/java/com/miml/c2k/domain/seat/Seat.java
@@ -1,5 +1,6 @@
 package com.miml.c2k.domain.seat;
 
+import com.miml.c2k.domain.schedule.Schedule;
 import com.miml.c2k.domain.screen.Screen;
 import com.miml.c2k.domain.ticket.Ticket;
 import jakarta.persistence.Column;
@@ -38,11 +39,16 @@ public class Seat {
     @JoinColumn(name = "ticket_id")
     private Ticket ticket;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private Schedule schedule;
+
     @Builder
-    public Seat(SeatNameType name, Screen screen, Ticket ticket) {
+    public Seat(SeatNameType name, Screen screen, Ticket ticket, Schedule schedule) {
         this.name = name;
         this.screen = screen;
         this.ticket = ticket;
+        this.schedule = schedule;
     }
 
     public void setTicket(Ticket ticket) {

--- a/src/main/java/com/miml/c2k/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/miml/c2k/domain/seat/repository/SeatRepository.java
@@ -1,8 +1,12 @@
 package com.miml.c2k.domain.seat.repository;
 
 import com.miml.c2k.domain.seat.Seat;
+import com.miml.c2k.domain.seat.Seat.SeatNameType;
+import jakarta.persistence.LockModeType;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
@@ -10,6 +14,9 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Query(value = "SELECT count(se) FROM Seat se JOIN Ticket t ON se.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
     int countReservedSeatsByScheduleId(Long scheduleId);
 
-    @Query("SELECT se FROM Seat se JOIN Ticket t ON se.ticket.id = t.id WHERE t.schedule.id = :scheduleId")
+    @Query("SELECT se FROM Seat se WHERE se.schedule.id = :scheduleId AND se.ticket IS NOT NULL")
     List<Seat> findAllReservedSeatsByScheduleId(Long scheduleId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Seat> findAllByScheduleIdAndNameIn(Long scheduleId, Collection<SeatNameType> names);
 }

--- a/src/test/java/com/miml/c2k/domain/DataFactoryUtil.java
+++ b/src/test/java/com/miml/c2k/domain/DataFactoryUtil.java
@@ -91,17 +91,18 @@ public class DataFactoryUtil {
         return screens;
     }
 
-    public static List<Seat> createReservedSeats(Ticket ticket, List<SeatNameType> seatNameTypes) {
+    public static List<Seat> createReservedSeats(Ticket ticket, Schedule schedule, List<SeatNameType> seatNameTypes) {
         return seatNameTypes.stream().map(
-                        seatNameType -> createReservedSeat(ticket, seatNameType))
+                        seatNameType -> createReservedSeat(ticket, schedule, seatNameType))
                 .toList();
     }
 
-    private static Seat createReservedSeat(Ticket ticket, SeatNameType seatNameType) {
+    private static Seat createReservedSeat(Ticket ticket, Schedule schedule, SeatNameType seatNameType) {
         return Seat.builder()
                 .name(seatNameType)
                 .screen(ticket.getSchedule().getScreen())
                 .ticket(ticket)
+                .schedule(schedule)
                 .build();
     }
 }

--- a/src/test/java/com/miml/c2k/domain/seat/controller/SeatControllerIntegrationTest.java
+++ b/src/test/java/com/miml/c2k/domain/seat/controller/SeatControllerIntegrationTest.java
@@ -29,12 +29,14 @@ import com.miml.c2k.domain.schedule.Schedule;
 import com.miml.c2k.domain.schedule.repository.ScheduleRepository;
 import com.miml.c2k.domain.screen.Screen;
 import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import com.miml.c2k.domain.seat.Seat;
 import com.miml.c2k.domain.seat.Seat.SeatNameType;
 import com.miml.c2k.domain.seat.dto.SeatRequestDto;
 import com.miml.c2k.domain.seat.repository.SeatRepository;
 import com.miml.c2k.domain.theater.repository.TheaterRepository;
 import com.miml.c2k.domain.ticket.repository.TicketRepository;
 import com.miml.c2k.global.auth.jwt.AuthTokensGenerator;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -79,8 +81,11 @@ class SeatControllerIntegrationTest {
     void setUp() {
         Screen screen = screenRepository.saveAll(
                 createScreens(theaterRepository.saveAll(createTheaters()))).get(0);
-        scheduleIdForTest = scheduleRepository.saveAll(
-                createSchedules(movieRepository.saveAll(createMoviesIsPlaying(1)), screen)).get(0).getId();
+        Schedule schedule = scheduleRepository.saveAll(
+            createSchedules(movieRepository.saveAll(createMoviesIsPlaying(1)), screen)).get(0);
+        scheduleIdForTest = schedule.getId();
+        Arrays.stream(SeatNameType.values()).forEach(seatNameType ->
+            seatRepository.save(Seat.builder().name(seatNameType).schedule(schedule).screen(screen).build()));
     }
 
     @AfterEach

--- a/src/test/java/com/miml/c2k/domain/seat/repository/SeatRepositoryTest.java
+++ b/src/test/java/com/miml/c2k/domain/seat/repository/SeatRepositoryTest.java
@@ -57,9 +57,9 @@ class SeatRepositoryTest {
                 createSchedules(movieRepository.saveAll(createMoviesIsPlaying(1)), screen)).get(0);
         Member member = memberRepository.save(createMember());
         Ticket ticket = ticketRepository.save(Ticket.builder().member(member).schedule(schedule).build());
-        List<Seat> seatsToReserve = createReservedSeats(ticket,
+        List<Seat> seatsToReserve = createReservedSeats(ticket, schedule,
                 Stream.of(SeatNameType.J11, SeatNameType.J12, SeatNameType.J13).toList());
-      
+
         seatRepository.saveAll(seatsToReserve);
 
         // when

--- a/src/test/java/com/miml/c2k/domain/seat/service/SeatServiceIntegrationTest.java
+++ b/src/test/java/com/miml/c2k/domain/seat/service/SeatServiceIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.miml.c2k.domain.seat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.miml.c2k.domain.member.Member;
+import com.miml.c2k.domain.member.OAuthProvider;
+import com.miml.c2k.domain.member.repository.MemberRepository;
+import com.miml.c2k.domain.movie.Movie;
+import com.miml.c2k.domain.movie.repository.MovieRepository;
+import com.miml.c2k.domain.schedule.dto.ScheduleSavingDto;
+import com.miml.c2k.domain.schedule.service.ScheduleService;
+import com.miml.c2k.domain.screen.Screen;
+import com.miml.c2k.domain.screen.repository.ScreenRepository;
+import com.miml.c2k.domain.seat.Seat.SeatNameType;
+import com.miml.c2k.domain.seat.dto.SeatRequestDto;
+import com.miml.c2k.domain.seat.dto.SeatResponseDto;
+import com.miml.c2k.domain.theater.Theater;
+import com.miml.c2k.domain.theater.repository.TheaterRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Slf4j
+public class SeatServiceIntegrationTest {
+
+    @Autowired
+    private SeatService seatService;
+    @Autowired
+    private MovieRepository movieRepository;
+    @Autowired
+    private ScreenRepository screenRepository;
+    @Autowired
+    private TheaterRepository theaterRepository;
+    @Autowired
+    private ScheduleService scheduleService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("동시에 같은 좌석을 예매할 수 없다.")
+    void success_to_not_reserve_same_seat_concurrently() throws Exception{
+        // given
+        Member leeYoungJi = memberRepository.save(
+            Member.builder().nickname("Lee Young Ji").email("lee@naver.com")
+                .oAuthProvider(OAuthProvider.KAKAO).build());
+        Member codeKunst = memberRepository.save(
+            Member.builder().nickname("Code KUNST").email("cokun@naver.com")
+                .oAuthProvider(OAuthProvider.KAKAO).build());
+        Movie movie = movieRepository.save(
+            Movie.builder().title("Go High").code("1004").audienceCount(100L).build());
+        Theater theater = theaterRepository.save(Theater.builder().name("High School Rapper").build());
+        Screen screen = screenRepository.save(Screen.builder().num(3).seatCount(10).theater(theater).build());
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        scheduleService.saveSchedule(
+            new ScheduleSavingDto(movie.getId(), screen.getId(), nowLocalDateTime,
+                nowLocalDateTime.plusHours(1)));
+
+        Long testScheduleId = scheduleService.getSchedulesBy(movie.getId(), theater.getId(),
+            nowLocalDateTime.toLocalDate()).get(0).getId();
+        SeatRequestDto seatRequestDto1 = SeatRequestDto.builder()
+            .seatNameTypes(List.of(SeatNameType.J10, SeatNameType.J11))
+            .scheduleId(testScheduleId).build();
+        SeatRequestDto seatRequestDto2 = SeatRequestDto.builder()
+            .seatNameTypes(List.of(SeatNameType.J11, SeatNameType.J12))
+            .scheduleId(testScheduleId).build();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch countDownLatch = new CountDownLatch(2);
+
+        // when
+        executorService.execute(() -> {
+            try {
+                seatService.reserveSeat(seatRequestDto1, leeYoungJi.getId());
+            } catch (Exception e) {
+                log.info("lee young ji encountered exception: {}", e.getMessage());
+            }
+            finally {
+                countDownLatch.countDown();
+            }
+        });
+        executorService.execute(() -> {
+            try {
+                seatService.reserveSeat(seatRequestDto2, codeKunst.getId());
+            } catch (Exception e) {
+                log.info("code KUNST encountered exception: {}", e.getMessage());
+            }
+            finally {
+                countDownLatch.countDown();
+            }
+        });
+        countDownLatch.await();
+
+        // then
+        List<SeatResponseDto> allSeats = seatService.getAllSeats(testScheduleId);
+        int reservedSeatCount = allSeats.stream()
+            .mapToInt(seat -> seat.isReserved() ? 1 : 0).sum();
+
+        assertThat(reservedSeatCount).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/miml/c2k/domain/seat/service/SeatServiceTest.java
+++ b/src/test/java/com/miml/c2k/domain/seat/service/SeatServiceTest.java
@@ -61,7 +61,7 @@ class SeatServiceTest {
                 screen).get(0);
         Ticket ticket = Ticket.builder().member(createMember()).schedule(schedule).build();
         List<Seat> reservedSeats = createReservedSeats(
-                ticket,
+                ticket, schedule,
                 Stream.of(SeatNameType.J11, SeatNameType.J12, SeatNameType.J13).toList());
         when(seatRepository.findAllReservedSeatsByScheduleId(schedule.getId())).thenReturn(
                 reservedSeats);

--- a/src/test/java/com/miml/c2k/domain/seat/service/SeatServiceTest.java
+++ b/src/test/java/com/miml/c2k/domain/seat/service/SeatServiceTest.java
@@ -83,22 +83,23 @@ class SeatServiceTest {
         Schedule schedule = createSchedules(
                 createMoviesIsPlaying(1),
                 screen).get(0);
-        Ticket ticket = Ticket.builder().member(createMember()).schedule(schedule).build();
-        List<Seat> reservedSeats = createReservedSeats(
-                ticket,
-                Stream.of(SeatNameType.J11, SeatNameType.J12, SeatNameType.J13).toList());
         Member member = createMember();
+        Ticket ticket = Ticket.builder().member(member).schedule(schedule).build();
         SeatRequestDto seatRequestDto = SeatRequestDto.builder()
                 .scheduleId(schedule.getId())
                 .seatNameTypes(
                         Stream.of(SeatNameType.J14, SeatNameType.J15, SeatNameType.J16).toList())
                 .build();
+        List<Seat> seatsToReserve = List.of(
+            Seat.builder().name(SeatNameType.J14).schedule(schedule).screen(screen).build(),
+            Seat.builder().name(SeatNameType.J15).schedule(schedule).screen(screen).build(),
+            Seat.builder().name(SeatNameType.J16).schedule(schedule).screen(screen).build());
 
         when(scheduleRepository.findById(schedule.getId())).thenReturn(Optional.of(schedule));
         when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
         when(ticketRepository.save(any(Ticket.class))).thenReturn(ticket);
-        when(seatRepository.findAllReservedSeatsByScheduleId(schedule.getId())).thenReturn(
-                reservedSeats);
+        when(seatRepository.findAllByScheduleIdAndNameIn(schedule.getId(), seatRequestDto.getSeatNameTypes())).thenReturn(
+                seatsToReserve);
 
         // when
         ReservedSeatResponseDto reservedSeatResponseDto
@@ -117,22 +118,24 @@ class SeatServiceTest {
         // given
         Screen screen = createScreens(createTheaters()).get(0);
         Schedule schedule = createSchedules(
-                createMoviesIsPlaying(1),
-                screen).get(0);
-        SeatNameType alreadyReservedSeat = SeatNameType.J11;
-        Ticket ticket = Ticket.builder().member(createMember()).schedule(schedule).build();
-        List<Seat> reservedSeats = createReservedSeats(
-                ticket,
-                Stream.of(SeatNameType.J11, SeatNameType.J12, SeatNameType.J13).toList());
+            createMoviesIsPlaying(1),
+            screen).get(0);
         Member member = createMember();
+        Ticket ticket = Ticket.builder().member(member).schedule(schedule).build();
+        List<Seat> seatsToReserve = List.of(
+            Seat.builder().name(SeatNameType.J14).schedule(schedule).screen(screen).ticket(ticket).build(),
+            Seat.builder().name(SeatNameType.J15).schedule(schedule).screen(screen).build(),
+            Seat.builder().name(SeatNameType.J16).schedule(schedule).screen(screen).ticket(ticket).build());
         SeatRequestDto seatRequestDto = SeatRequestDto.builder()
-                .scheduleId(schedule.getId())
-                .seatNameTypes(
-                        Stream.of(alreadyReservedSeat, SeatNameType.J15, SeatNameType.J16).toList())
-                .build();
+            .scheduleId(schedule.getId())
+            .seatNameTypes(
+                Stream.of(SeatNameType.J14, SeatNameType.J15, SeatNameType.J16).toList())
+            .build();
 
-        when(seatRepository.findAllReservedSeatsByScheduleId(schedule.getId())).thenReturn(
-                reservedSeats);
+        when(scheduleRepository.findById(schedule.getId())).thenReturn(Optional.of(schedule));
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(seatRepository.findAllByScheduleIdAndNameIn(schedule.getId(), seatsToReserve.stream().map(Seat::getName).toList())).thenReturn(
+            seatsToReserve);
 
         // when
         RuntimeException exception
@@ -140,6 +143,6 @@ class SeatServiceTest {
                 () -> seatService.reserveSeat(seatRequestDto, member.getId()));
 
         // then
-        assertThat(exception.getMessage(), equalTo(alreadyReservedSeat + "는 이미 예약된 좌석입니다."));
+        assertThat(exception.getMessage(), equalTo("J14, J16(은)는 이미 예약된 좌석입니다."));
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #41 
Resolved #42 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* `Schedule`과 `Seat`를 1:N 관계로 설정했습니다. 이에 따라 좌석들은 상영 일정에 따라 구분됩니다.
  * 따라서 관리자 페이지에서 상영 일정을 생성하면 티켓이 설정되지 않은 채로 좌석들이 전부 추가됩니다.
  * 만약 추후 로직을 구현하실 때 좌석을 필요로 한다면 좌석에 이제 상영 일정을 넣어주셔야 합니다!!
* `ScheduleService` 메서드들에 `@Transactional`을 추가했습니다. 통합 테스트를 하지않고 단위 테스트를 작성하다보니 `LazyInitializationException`을 간과했었습니다.
* 동시성 관련 코드를 추가하면서 `SeatService` 내 `reserveSeat` 메서드를 조금 수정했습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
동시성을 위해 `SeatRepository` 내 `findAllByScheduleIdAndNameIn` 메서드를 추가했고 `findAllReservedSeatsByScheduleId` 메서드의 쿼리문을 수정했는데 혹시 문제있는지(생각치 못한 엣지 케이스, 놓치는 데이터들이 있는지) 확인해 주시면 감사하겠습니다!